### PR TITLE
Specify mcap chunksize for compression

### DIFF
--- a/lxo_config.yaml
+++ b/lxo_config.yaml
@@ -5,4 +5,5 @@ cloud_upload_directory: "/mnt/vdb/data"
 clean_up: false
 upload_attempts: 3
 mcap_path: "/home/lxo/mcap"
+mcap_compression_chunk_size: 62914560 # ~60 MB
 parallel_processes: 5

--- a/rhaegal_config.yaml
+++ b/rhaegal_config.yaml
@@ -5,4 +5,5 @@ cloud_upload_directory: "/mnt/vdb/data/upload_test"
 clean_up: false
 upload_attempts: 3
 mcap_path: "/home/hector/mcap"
+mcap_compression_chunk_size: 62914560 # ~60 MB
 parallel_processes: 5


### PR DESCRIPTION
- Add `mcap_compression_chunksize` parameter to define the chunksize for compression
- Introduce a `validate_config()` function to enforce the existence of required parameters and format. Throw exception if not satisfied
- Add `mcap_compression_chunksize` to `lxo_config.yaml` and `rhaegal_config.yaml`