### PR TITLE
Add a workaround to fix ROS expired signing key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,28 @@
 FROM ros:humble-ros-base-jammy AS base
 
+# Temp fix for ROS expired signing key issue see:
+#   https://discourse.ros.org/t/ros-signing-key-migration-guide/43937/22?u=hect945
+# Remove when this PR is merged:
+#   https://github.com/docker-library/official-images/pull/19162
+
+# Use bash with pipefail wherever pipelines are present
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN rm /etc/apt/sources.list.d/ros2-latest.list \
+  && rm /usr/share/keyrings/ros2-latest-archive-keyring.gpg
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# hadolint ignore=SC2086
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s "https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest" | grep -F "tag_name" | awk -F\" '{print $4}') ;\
+    curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+    && apt-get update \
+    && apt-get -y --quiet --no-install-recommends install /tmp/ros2-apt-source.deb \
+    && rm -f /tmp/ros2-apt-source.deb \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install key dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
- Modified Dockerfile to manually update the key as per this [discussion](https://discourse.ros.org/t/ros-signing-key-migration-guide/43937/22)