### PR TITLE
Add rosbag export functionality to Data Manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ENV EXPORTER=$ROS_WS/src/tartan_rosbag_exporter
-RUN git clone -b v1.0.0 https://github.com/ipab-rad/tartan_rosbag_exporter.git $EXPORTER \
+RUN git clone -b 1.0.0 https://github.com/ipab-rad/tartan_rosbag_exporter.git $EXPORTER \
     && . /opt/ros/"$ROS_DISTRO"/setup.sh \
     && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release \
     && rm -rf $ROS_WS/build $EXPORTER

--- a/scripts/data_manager/data_manager.py
+++ b/scripts/data_manager/data_manager.py
@@ -92,7 +92,7 @@ class DataManager:
 
         Call the `ros2_bag_exporter bag_exporter` node with the given
         rosbag directory, `self.output directory`, and
-        `self.exporter_config_file`.Parse the node stdout + stderr to
+        `self.exporter_config_file`. Parse the node stdout + stderr to
         locate and return the path where data was exported, or
         None if extraction fails.
 


### PR DESCRIPTION
- Define an `export_rosbag_recording()` function to run the `ros2_bag_exporter bag_exporter` ROS node and extract the exported directory from the stdout + stderr output
- Call `export_rosbag_recording()` when a new recording is found
- Add new script arguments `--output_directory` and `export_config_file` to define the parent directory for the exported data and the configuration file for `ros2_bag_exporter bag_exporter` node respectively.
  - Convert `rosbags_directory` to a flag argument rather than a positional argument.
- Update `Dockerfile` to install the correct version of the `ros2_bag_exporter` package.