### PR TITLE
Fix: Handle segments.ai client exceptions

### DIFF
--- a/scripts/data_manager/data_manager.py
+++ b/scripts/data_manager/data_manager.py
@@ -206,8 +206,15 @@ class DataManager:
                     dataset_name = self.dataset_creator.create(
                         export_directory, Path(new_recording_path)
                     )
-
-                    self.logger.info(f'New Dataset created: {dataset_name}\n')
+                    if dataset_name:
+                        self.logger.info(
+                            f'New Dataset created: {dataset_name}\n'
+                        )
+                    else:
+                        self.logger.warning(
+                            'Failed to create dataset from recording '
+                            f'{Path(new_recording_path).name}'
+                        )
 
                 time.sleep(self.POLLING_INTERVAL_SEC)
         except KeyboardInterrupt:

--- a/scripts/labelling_preproc/common/response.py
+++ b/scripts/labelling_preproc/common/response.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 
 class PreprocessingError(Enum):
@@ -21,5 +22,6 @@ class PreprocessingResponse:
     """Define a response for labelling pre-processing actions."""
 
     ok: bool = None
+    metadata: Any = None
     error: PreprocessingError = None
     error_message: str = None

--- a/scripts/labelling_preproc/common/response.py
+++ b/scripts/labelling_preproc/common/response.py
@@ -1,0 +1,25 @@
+"""Module for defining preprocessing response and error types."""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class PreprocessingError(Enum):
+    """Define possible errors for labelling pre-processing."""
+
+    SegmentsValidationError = 'SegmentsValidationError'
+    SegmentsAPILimitError = 'SegmentsAPILimitError'
+    SegmentsNotFoundError = 'SegmentsNotFoundError'
+    SegmentsNetworkError = 'SegmentsNetworkError'
+    SegmentsAlreadyExistsError = 'SegmentsAlreadyExistsError'
+    SegmentsTimeoutError = 'SegmentsTimeoutError'
+    SegmentsUnknownError = 'SegmentsUnknownError'
+
+
+@dataclass
+class PreprocessingResponse:
+    """Define a response for labelling pre-processing actions."""
+
+    ok: bool = None
+    error: PreprocessingError = None
+    error_message: str = None

--- a/scripts/labelling_preproc/common/s3_client.py
+++ b/scripts/labelling_preproc/common/s3_client.py
@@ -8,7 +8,7 @@ import boto3
 
 from botocore.config import Config
 
-from segments import SegmentsClient, exceptions
+from segments import SegmentsClient
 
 
 class TartanAsset:
@@ -70,84 +70,6 @@ class SegmentS3Client(S3Client):
         segment_asset = self.s3_client.upload_asset(file, file_key)
         asset = TartanAsset(segment_asset.url, segment_asset.uuid)
         return asset
-
-    def print_datasets(self) -> None:
-        """List all current datasets on Segments.ai."""
-        datasets = self.s3_client.get_datasets()
-        for dataset in datasets:
-            print(dataset.name, dataset.description)
-
-    def verify_dataset(self, dataset_name: str) -> None:
-        """
-        Verify that a dataset exists on Segments.ai.
-
-        Args:
-            dataset_name: The name of the dataset to verify.
-
-        Raises:
-            ValidationError: If dataset validation fails.
-            APILimitError: If the API limit is exceeded.
-            NotFoundError: If the dataset is not found.
-            TimeoutError: If the request times out.
-        """
-        try:
-            self.s3_client.get_dataset(dataset_name)
-        except exceptions.ValidationError as e:
-            raise exceptions.ValidationError(
-                f'Failed to validate "{dataset_name}" dataset.'
-            ) from e
-        except exceptions.APILimitError as e:
-            raise exceptions.APILimitError('API limit exceeded.') from e
-        except exceptions.NotFoundError as e:
-            raise exceptions.NotFoundError(
-                f'Dataset "{dataset_name}" does not exist. '
-                f'Please provide an existent dataset.'
-            ) from e
-        except exceptions.TimeoutError as e:
-            raise exceptions.TimeoutError(
-                'Request timed out. Try again later.'
-            ) from e
-
-    def add_sample(
-        self, dataset_name: str, sequence_name: str, attributes: dict
-    ) -> None:
-        """
-        Add a sample to a Segments.ai dataset.
-
-        Args:
-            dataset_name: The name of the dataset.
-            sequence_name: The sequence name within the dataset.
-            attributes: A dictionary containing sample attributes.
-
-        Raises:
-            ValidationError: If sample validation fails.
-            APILimitError: If the API limit is exceeded.
-            NotFoundError: If the dataset is not found.
-            AlreadyExistsError: If the sequence already exists.
-            TimeoutError: If the request times out.
-        """
-        try:
-            self.s3_client.add_sample(dataset_name, sequence_name, attributes)
-        except exceptions.ValidationError as e:
-            raise exceptions.ValidationError(
-                'Failed to validate sample.'
-            ) from e
-        except exceptions.APILimitError as e:
-            raise exceptions.APILimitError('API limit exceeded.') from e
-        except exceptions.NotFoundError as e:
-            raise exceptions.NotFoundError(
-                f'Dataset "{dataset_name}" does not exist. '
-                f'Please provide an existing dataset.'
-            ) from e
-        except exceptions.AlreadyExistsError as e:
-            raise exceptions.AlreadyExistsError(
-                f'The sequence "{sequence_name}" '
-                f'already exists in "{dataset_name}"'
-            ) from e
-        except exceptions.TimeoutError as e:
-            raise exceptions.TimeoutError(
-                'Request timed out while adding sample.'
-            ) from e
 
 
 class EIDFfS3Client(S3Client):

--- a/scripts/labelling_preproc/common/segments_client_wrapper.py
+++ b/scripts/labelling_preproc/common/segments_client_wrapper.py
@@ -1,0 +1,116 @@
+"""Segments.ai client wrapper module."""
+
+from labelling_preproc.common.response import (
+    PreprocessingError,
+    PreprocessingResponse,
+)
+
+from segments import SegmentsClient, exceptions
+
+
+class SegmentsClientWrapper:
+    """Class to interface with Segments.ai SDK."""
+
+    def __init__(self, api_key: str):
+        """
+        Initialise the Segments client with an API key.
+
+        Args:
+            api_key: Segments.ai API key.
+        """
+        self.client = SegmentsClient(api_key)
+
+    def verify_dataset(self, dataset_name: str) -> PreprocessingResponse:
+        """
+        Verify that a dataset exists on Segments.ai.
+
+        Args:
+            dataset_name: The name of the dataset to verify.
+        Returns:
+            PreprocessingResponse: Indicates success or failure and error info.
+        """
+        return self._handle_segments_errors(
+            func=self.client.get_dataset, dataset_identifier=dataset_name
+        )
+
+    def add_sample(
+        self, dataset_name: str, sequence_name: str, _attributes: dict
+    ) -> PreprocessingResponse:
+        """
+        Add a sample to a Segments.ai dataset.
+
+        Args:
+            dataset_name: The name of the dataset.
+            sequence_name: The sequence name within the dataset.
+            attributes: A dictionary containing sample attributes.
+
+        Returns:
+            PreprocessingResponse: Indicates success or failure and error info.
+        """
+        return self._handle_segments_errors(
+            func=self.client.add_sample,
+            dataset_identifier=dataset_name,
+            name=sequence_name,
+            attributes=_attributes,
+        )
+
+    def _handle_segments_errors(
+        self, func, *args, **kwargs
+    ) -> PreprocessingResponse:
+        """
+        Handle errors generically for SegmentsClient operations.
+
+        Args:
+            context_str: A descriptive action string for context in
+                         error messages.
+            func (callable): The client method to call.
+            *args, **kwargs: Arguments for the client method.
+
+        Returns:
+            PreprocessingResponse: Response indicating success or error.
+        """
+        try:
+            func(*args, **kwargs)
+            return PreprocessingResponse(ok=True)
+        except exceptions.ValidationError as e:
+            return PreprocessingResponse(
+                ok=False,
+                error=PreprocessingError.SegmentsValidationError,
+                error_message=str(e),
+            )
+        except exceptions.APILimitError as e:
+            return PreprocessingResponse(
+                ok=False,
+                error=PreprocessingError.SegmentsAPILimitError,
+                error_message=str(e),
+            )
+        except exceptions.NotFoundError as e:
+            return PreprocessingResponse(
+                ok=False,
+                error=PreprocessingError.SegmentsNotFoundError,
+                error_message=str(e),
+            )
+        except exceptions.AlreadyExistsError as e:
+            return PreprocessingResponse(
+                ok=False,
+                error=PreprocessingError.SegmentsAlreadyExistsError,
+                error_message=str(e),
+            )
+        except exceptions.NetworkError as e:
+            return PreprocessingResponse(
+                ok=False,
+                error=PreprocessingError.SegmentsNetworkError,
+                error_message=str(e),
+            )
+        except exceptions.TimeoutError as e:
+            return PreprocessingResponse(
+                ok=False,
+                error=PreprocessingError.SegmentsTimeoutError,
+                error_message=str(e),
+            )
+        except Exception as e:  # noqa: B902
+            return PreprocessingResponse(
+                ok=False,
+                error=PreprocessingError.SegmentsUnknownError,
+                error_message=str(e),
+            )

--- a/scripts/labelling_preproc/common/segments_client_wrapper.py
+++ b/scripts/labelling_preproc/common/segments_client_wrapper.py
@@ -5,7 +5,7 @@ from labelling_preproc.common.response import (
     PreprocessingResponse,
 )
 
-from segments import SegmentsClient, exceptions
+from segments import SegmentsClient, exceptions, typing
 
 
 class SegmentsClientWrapper:
@@ -54,6 +54,42 @@ class SegmentsClientWrapper:
             attributes=_attributes,
         )
 
+    def add_dataset(
+        self,
+        dataset_name: str,
+        task_type: str,
+        dataset_attributes: dict,
+        readme_str: str,
+        organisation_name: str,
+    ) -> PreprocessingResponse:
+        """
+        Add a new dataset in Segments.ai.
+
+        For further reference see:
+             https://sdkdocs.segments.ai/en/latest/client.html#create-a-dataset
+
+        Args:
+            dataset_name: Name of the dataset.
+            task_type: The type of the dataset.
+            dataset_attributes: A dictionary containing format and labels'
+                                categories.
+            readme_str: A string describing the summary of the dataset.
+            organisation_name: Segments.ai organisation name
+                               where the dataset is going to be created.
+        Returns:
+            PreprocessingResponse: Indicates success or failure and error info.
+        """
+        return self._handle_segments_errors(
+            func=self.client.add_dataset,
+            name=dataset_name,
+            task_type=task_type,
+            task_attributes=dataset_attributes,
+            category=typing.Category.STREET_SCENERY,  # Automotive category
+            readme=readme_str,
+            enable_3d_cuboid_rotation=True,
+            organization=organisation_name,
+        )
+
     def _handle_segments_errors(
         self, func, *args, **kwargs
     ) -> PreprocessingResponse:
@@ -70,8 +106,8 @@ class SegmentsClientWrapper:
             PreprocessingResponse: Response indicating success or error.
         """
         try:
-            func(*args, **kwargs)
-            return PreprocessingResponse(ok=True)
+            func_result = func(*args, **kwargs)
+            return PreprocessingResponse(ok=True, metadata=func_result)
         except exceptions.ValidationError as e:
             return PreprocessingResponse(
                 ok=False,

--- a/scripts/labelling_preproc/dataset_creator.py
+++ b/scripts/labelling_preproc/dataset_creator.py
@@ -3,16 +3,21 @@
 import argparse
 import json
 import logging
+import time
 from pathlib import Path
+from typing import List, Optional
 
+import colorlog
 
 from labelling_preproc.add_segmentsai_sample import SegmentsSampleCreator
+from labelling_preproc.common.response import PreprocessingError
+from labelling_preproc.common.segments_client_wrapper import (
+    SegmentsClientWrapper,
+)
 from labelling_preproc.common.utils import file_exists, get_env_var
 from labelling_preproc.generate_ego_trajectory import EgoTrajectoryGenerator
 from labelling_preproc.upload_data import AssetUploader
 
-from segments import SegmentsClient
-from segments.typing import Category
 
 import yaml
 
@@ -42,7 +47,8 @@ class DatasetCreator:
         Args:
             dataset_attributes_file: Absolute path to the dataset attributes
                                      JSON file.
-            debug_mode: Enable debug logs.
+            s3_organisation: Name of the AWS S3 organisation to target
+            logger: Logger object for level-based logging
         """
         self.logger = logger
         # Unique organisation name where Segments.ai datasets will be created
@@ -53,11 +59,13 @@ class DatasetCreator:
             self.dataset_attributes = json.load(f)
 
         api_key = get_env_var('SEGMENTS_API_KEY')
-        self.client = SegmentsClient(api_key)
+        self.client = SegmentsClientWrapper(api_key)
 
         self.trajectory_generator = EgoTrajectoryGenerator()
         self.asset_uploader = AssetUploader(s3_organisation)
-        self.segments_sample_creator = SegmentsSampleCreator()
+        self.segments_sample_creator = SegmentsSampleCreator(self.client)
+
+        self.RETRY_INTERVAL_SEC = 10
 
     def get_rosbag_file_name(self, sequence_export: Path) -> str:
         """
@@ -75,16 +83,56 @@ class DatasetCreator:
         # Get the first and only rosbag file name from the list
         return rosbags_list[0]
 
+    def sort_sub_directories(self, export_directory: Path) -> List[Path]:
+        """
+        Return a list of subdirectories sorted by their numeric suffix.
+
+        Assumes each subdirectory name ends with '_N' where N is an integer.
+
+        Args:
+            export_directory (Path): The parent directory containing
+                                     subdirectories to sort.
+        Returns:
+            List[Path]: Sorted list of subdirectory paths.
+        """
+
+        def extract_suffix_num(path: Path) -> int:
+            """
+            Extract the numeric suffix from a path's name.
+
+            Assuming the format '<path_name>_N'. If the format is invalid,
+            return a high number to sort it at the end.
+            """
+            try:
+                return int(path.name.rsplit('_', 1)[-1])
+            except (IndexError, ValueError):
+                return 10000
+
+        subdirs = []
+        for item in export_directory.iterdir():
+            if item.is_dir():
+                subdirs.append(item)
+
+        return sorted(subdirs, key=extract_suffix_num)
+
     def add_dataset(
         self, dataset_name: Path, recording_directory: Path
-    ) -> str:
+    ) -> Optional[str]:
         """
         Add a new dataset to Segments.ai.
+
+        If the creation fails and the error is recoverable,
+        the function will keep trying every self.RETRY_INTERVAL_SEC seconds.
+        If an unrecoverable error happens, the dataset of this ROSbag recording
+        will be skipped and logged.
 
         Args:
             dataset_name: Name of the dataset to be created
             recording_directory: Directory containing the ROS bag
                                         recording
+        Returns:
+            An string with the dataset name if the creation was
+             successful, none otherwise.
         """
         recording_name = recording_directory.name
         task_type = 'multisensor-sequence'
@@ -97,17 +145,97 @@ class DatasetCreator:
             f'\t`sequence_<N> -> {recording_name}_<N>.mcap`\n'
         )
 
-        dataset = self.client.add_dataset(
-            name=dataset_name,
-            task_type=task_type,
-            task_attributes=self.dataset_attributes,
-            category=Category.STREET_SCENERY,
-            readme=readme_str,
-            enable_3d_cuboid_rotation=True,
-            organization=self.ORGANISATION_NAME,
-        )
+        while True:
+            response = self.client.add_dataset(
+                dataset_name,
+                task_type,
+                self.dataset_attributes,
+                readme_str,
+                self.ORGANISATION_NAME,
+            )
 
-        return dataset.full_name
+            if response.ok:
+                # Obtain dataset full name from the response' metadata
+                return response.metadata.full_name
+            elif response.error in {
+                PreprocessingError.SegmentsAPILimitError,
+                PreprocessingError.SegmentsNetworkError,
+                PreprocessingError.SegmentsTimeoutError,
+            }:
+                # We can recover from these errors, so we wait for few seconds
+                # before continuing with the loop
+                self.logger.warning(
+                    f'[DatasetCreator] Error {response.error.value} happened '
+                    f'when creating a "{dataset_name}" dataset'
+                    f'\nRetrying in {self.RETRY_INTERVAL_SEC} seconds...'
+                    f'\nMore details:\n{response.error_message}'
+                )
+                time.sleep(self.RETRY_INTERVAL_SEC)
+            else:
+                # Other errors are not recoverable for this new dataset
+                # so we log the error and skip this ROS bag recording
+                self.logger.warning(
+                    f'[DatasetCreator] An unrecoverable error '
+                    f'{response.error.value} happened '
+                    f'when creating "{dataset_name}" dataset, '
+                    f'skipping {recording_name} recording.\n'
+                    f'More details: {response.error_message}'
+                )
+                return None
+
+    def create_sample(
+        self, dataset_full_name: str, export_sub_directory: Path
+    ) -> bool:
+        """
+        Create a Segments.ai sample for the given export sub directory.
+
+        If the creation fails and the error is recoverable,
+        the function will keep trying every self.RETRY_INTERVAL_SEC seconds.
+        If an unrecoverable error happens, the sample of this export
+        sub-directory will be skipped and logged.
+
+        Args:
+            dataset_full_name: Full name of the Segments.ai dataset
+            export_sub_directory: Path to the directory containing the exported
+                                  data for the sample
+        Returns:
+            bool: True if the sample was created successfully, False otherwise.
+        """
+        while True:
+            sequence_name = export_sub_directory.name
+            response = self.segments_sample_creator.add(
+                dataset_full_name, sequence_name, export_sub_directory
+            )
+            if response.ok:
+                self.logger.debug(
+                    f'[DatasetCreator] Sample "{sequence_name}" added'
+                )
+                return True
+            elif response.error in {
+                PreprocessingError.SegmentsAPILimitError,
+                PreprocessingError.SegmentsNetworkError,
+                PreprocessingError.SegmentsTimeoutError,
+            }:
+                # We can recover from these errors, so we wait for few seconds
+                # before continuing with the loop
+                self.logger.warning(
+                    f'[DatasetCreator] Error {response.error.value} happened '
+                    f'when adding sample "{sequence_name}"'
+                    f'\nRetrying in {self.RETRY_INTERVAL_SEC} seconds...'
+                    f'\nMore details:\n{response.error_message}'
+                )
+                time.sleep(self.RETRY_INTERVAL_SEC)
+            else:
+                # Other errors are not recoverable for this sample
+                # so we log the error and skip this sample
+                self.logger.warning(
+                    '[DatasetCreator] An unrecoverable error '
+                    f'{response.error.value} happened when '
+                    f'adding sample "{sequence_name}", '
+                    f'skipping it.\n'
+                    f'More details:\n{response.error_message}'
+                )
+                return False
 
     def create(self, export_directory: Path, recording_directory: Path) -> str:
         """
@@ -116,7 +244,7 @@ class DatasetCreator:
         Args:
             recording_directory: Directory containing the recording
                                  ROS bag files
-            export_directory: Directory containing the recording expoted data
+            export_directory: Directory containing the recording exported data
         """
         # Use rosbag export directory name as dataset name
         dataset_name = export_directory.name
@@ -124,37 +252,38 @@ class DatasetCreator:
         # Create a Segments.ai dataset
         dataset_full_name = self.add_dataset(dataset_name, recording_directory)
 
+        if not dataset_full_name:
+            # If we couldn't create a dataset, it may be due to an
+            # unrecoverable error, thus, early return
+            return None
+
         self.logger.debug(
             f'[DatasetCreator] New dataset added: {dataset_full_name}'
         )
 
-        # Iterate through subdirectories in the export directory
+        export_sub_directory_list = self.sort_sub_directories(export_directory)
+
+        # Iterate through sub-directories in the export directory
         # and create a Segments.ai sample for each
-        for export_sub_directory in export_directory.iterdir():
-            if export_sub_directory.is_dir():
-                self.logger.debug(
-                    '[DatasetCreator] Processing directory: '
-                    f'{export_sub_directory}'
-                )
+        for export_sub_directory in export_sub_directory_list:
+            self.logger.debug(
+                '[DatasetCreator] Processing directory: '
+                f'{export_sub_directory}'
+            )
 
-                # Generate ego trajectory from export's ROS bag
-                rosbag_file_name = self.get_rosbag_file_name(
-                    export_sub_directory
-                )
+            # Generate ego trajectory from export's ROS bag
+            rosbag_file_name = self.get_rosbag_file_name(export_sub_directory)
 
-                rosbag_file = recording_directory / rosbag_file_name
-                self.trajectory_generator.run_mola_lidar_odometry(
-                    str(rosbag_file), str(export_sub_directory)
-                )
+            rosbag_file = recording_directory / rosbag_file_name
+            self.trajectory_generator.run_mola_lidar_odometry(
+                str(rosbag_file), str(export_sub_directory)
+            )
 
-                # Upload the directory to the cloud
-                self.asset_uploader.run(export_sub_directory.resolve())
+            # Upload the directory to the cloud
+            self.asset_uploader.run(export_sub_directory.resolve())
 
-                # Create a multi-sensor sequence in Segments.ai
-                sequence_name = export_sub_directory.name
-                self.segments_sample_creator.add(
-                    dataset_full_name, sequence_name, export_sub_directory
-                )
+            # Create Segments.ai sample
+            self.create_sample(dataset_full_name, export_sub_directory)
 
         return dataset_full_name
 
@@ -195,17 +324,19 @@ def main():
 
     # Define basic logger
     logger = logging.getLogger('DatasetCreator')
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging.DEBUG)
     handler = logging.StreamHandler()
     handler.setFormatter(
-        logging.Formatter('%(asctime)s [%(name)s] %(levelname)s: %(message)s')
+        colorlog.ColoredFormatter(
+            '%(asctime)s %(log_color)s%(levelname)s%(reset)s: %(message)s'
+        )
     )
     logger.addHandler(handler)
 
     dataset_creator = DatasetCreator(
         dataset_attributes_file=dataset_attributes_file,
+        s3_organisation='eidf',
         logger=logger,
-        debug_mode=False,
     )
 
     dataset_creator.create(export_directory, recording_directory)

--- a/scripts/labelling_preproc/dataset_creator.py
+++ b/scripts/labelling_preproc/dataset_creator.py
@@ -103,10 +103,11 @@ class DatasetCreator:
             Assuming the format '<path_name>_N'. If the format is invalid,
             return a high number to sort it at the end.
             """
+            TEN_THOUSAND = 10000
             try:
                 return int(path.name.rsplit('_', 1)[-1])
             except (IndexError, ValueError):
-                return 10000
+                return TEN_THOUSAND
 
         subdirs = []
         for item in export_directory.iterdir():
@@ -131,7 +132,7 @@ class DatasetCreator:
             recording_directory: Directory containing the ROS bag
                                         recording
         Returns:
-            An string with the dataset name if the creation was
+            A string with the dataset name if the creation was
              successful, none otherwise.
         """
         recording_name = recording_directory.name
@@ -155,15 +156,15 @@ class DatasetCreator:
             )
 
             if response.ok:
-                # Obtain dataset full name from the response' metadata
+                # Obtain dataset full name from the response's metadata
                 return response.metadata.full_name
             elif response.error in {
                 PreprocessingError.SegmentsAPILimitError,
                 PreprocessingError.SegmentsNetworkError,
                 PreprocessingError.SegmentsTimeoutError,
             }:
-                # We can recover from these errors, so we wait for few seconds
-                # before continuing with the loop
+                # We can recover from these errors, so we wait for a few
+                # seconds before continuing with the loop
                 self.logger.warning(
                     f'[DatasetCreator] Error {response.error.value} happened '
                     f'when creating a "{dataset_name}" dataset'
@@ -216,8 +217,8 @@ class DatasetCreator:
                 PreprocessingError.SegmentsNetworkError,
                 PreprocessingError.SegmentsTimeoutError,
             }:
-                # We can recover from these errors, so we wait for few seconds
-                # before continuing with the loop
+                # We can recover from these errors, so we wait for a few
+                # seconds before continuing with the loop
                 self.logger.warning(
                     f'[DatasetCreator] Error {response.error.value} happened '
                     f'when adding sample "{sequence_name}"'
@@ -271,7 +272,7 @@ class DatasetCreator:
                 f'{export_sub_directory}'
             )
 
-            # Generate ego trajectory from export's ROS bag
+            # Generate ego trajectory from export directory's ROS bag
             rosbag_file_name = self.get_rosbag_file_name(export_sub_directory)
 
             rosbag_file = recording_directory / rosbag_file_name


### PR DESCRIPTION
Avoid throwing Segments.ai exceptions  
  - Move `verify_dataset()` and `add_sample()` functions from
    `SegmentsS3Client` to a new class `SegmentsClientWrapper`. As these
     functions do not match semantically with the S3 client scope.
    - Return a new `PreprocessingResponse` object for each 
      Segments.ai's possible exceptions with their error details. And,
      assign any object received from the `SegmentsClient` methods to
      a `metadata` member
    - Add `response.py` module to define `PreprocessingResponse` and
      `PreprocessingError` objects to define the response and possible errors.
    
 Add a recovery mechanism for the `DatasetCreator` #57 
  - Catch Segment.ai client actions' responses and act accordingly.
    - Use `SegmentsClientWrapper` instead of using `SegmentsClient` directly to
      receive `PreprocessingResponse` objects
    - Modify `add_dataset()` to handle errors and recover if possible
      - Implement an infinite loop with early return on success
      - Retry operation  if the errors are `SegmentsAPILimitError`,
        `SegmentsNetworkError` or `SegmentsTimeoutError`
        Skip this ROSbag recording's dataset on other errors.
    - Introduce `create_sample()` method to enclose a recovery mechanism
        for creating a sample.
        - Implement an infinite loop with early return on success
        - Retry operation  if the errors are `SegmentsAPILimitError`,
          `SegmentsNetworkError` or `SegmentsTimeoutError`
          Skip the current sample on other errors
    - Define `RETRY_INTERVAL_SEC` constant to control the retry interval,
        defaulting to 10 seconds
  - Add `sort_sub_directories()` method to ensure the sub-directories are
    processed in suffix order
  - Set `DEBUG` logging level as default and apply color formatting. This
    only applies when the script is run directly, not when imported.
  - Fix missing arguments when creating `DatasetCreator` and running
    the script directly
  
  - Modify `SegmentsSampleCreator` to:
    - Use the new `SegmentsClientWrapper` instead of `SegmentsS3Client`
    - Return `PreprocessingResponse` objects instead of
      throwing Segments.ai client exceptions
    - Create and pass a `SegmentsClientWrapper` instance to
      `DatasetCreator` when running the script directly. Log any errors.
  
Log dataset creation response in `DataManager`
