### PR TITLE
Upgrade tartan_rosbag_exporter ROS pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ENV EXPORTER=$ROS_WS/src/tartan_rosbag_exporter
-RUN git clone -b 1.0.0 https://github.com/ipab-rad/tartan_rosbag_exporter.git $EXPORTER \
+RUN git clone -b 1.1.0 https://github.com/ipab-rad/tartan_rosbag_exporter.git $EXPORTER \
     && . /opt/ros/"$ROS_DISTRO"/setup.sh \
     && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release \
     && rm -rf $ROS_WS/build $EXPORTER

--- a/config/av_sensor_export_config.yaml
+++ b/config/av_sensor_export_config.yaml
@@ -73,7 +73,7 @@ topics:
 
   - name: "/tf_static"
     type: "TF"
-    sample_interval: 0
+    sample_interval: 1
     topic_dir: "extrinsics"
 
 #  # Configuration for IMU


### PR DESCRIPTION
- Modify Dockerfile to git pull version 1.1.0
- Change `\tf_static` `sample_interval` param from 0 to 1 to avoid zero division errors with the new package version.